### PR TITLE
Use inspect without XState required

### DIFF
--- a/.changeset/tender-adults-watch.md
+++ b/.changeset/tender-adults-watch.md
@@ -1,0 +1,5 @@
+---
+"@statelyai/inspect": patch
+---
+
+You can now use `@statelyai/inspect` without installing `xstate`.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,8 +1,9 @@
-import { AnyEventObject, Observer, Subscribable, toObserver } from 'xstate';
+import type { AnyEventObject, Observer, Subscribable } from 'xstate';
 import { Adapter, Inspector, StatelyInspectionEvent } from './types';
 import { InspectorOptions, createInspector } from './createInspector';
 import safeStringify from 'safe-stable-stringify';
 import { UselessAdapter } from './useless';
+import { toObserver } from './utils';
 
 interface BrowserReceiver extends Subscribable<StatelyInspectionEvent> {}
 

--- a/src/createInspector.ts
+++ b/src/createInspector.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 import { toEventObject } from './utils';
 import { Inspector } from './types';
-import { AnyActorRef, InspectionEvent, Snapshot } from 'xstate';
+import type { AnyActorRef, InspectionEvent, Snapshot } from 'xstate';
 import pkg from '../package.json';
 import { idleCallback } from './idleCallback';
 import safeStringify from 'safe-stable-stringify';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnyActorRef,
   AnyEventObject,
   InspectionEvent,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { AnyEventObject, AnyActorRef } from 'xstate';
+import type { AnyEventObject, AnyActorRef, Observer } from 'xstate';
 
 export function toEventObject(event: AnyEventObject | string): AnyEventObject {
   if (typeof event === 'string') {
@@ -15,4 +15,21 @@ export function isActorRef(actorRef: any): actorRef is AnyActorRef {
     typeof actorRef.sessionId === 'string' &&
     typeof actorRef.send === 'function'
   );
+}
+
+export function toObserver<T>(
+  nextHandler?: Observer<T> | ((value: T) => void),
+  errorHandler?: (error: any) => void,
+  completionHandler?: () => void
+): Observer<T> {
+  const isObserver = typeof nextHandler === 'object';
+  const self = isObserver ? nextHandler : undefined;
+
+  return {
+    next: (isObserver ? nextHandler.next : nextHandler)?.bind(self),
+    error: (isObserver ? nextHandler.error : errorHandler)?.bind(self),
+    complete: (isObserver ? nextHandler.complete : completionHandler)?.bind(
+      self
+    ),
+  };
 }

--- a/src/webSocket.ts
+++ b/src/webSocket.ts
@@ -2,7 +2,8 @@ import { InspectorOptions, createInspector } from './createInspector';
 import { Adapter, StatelyInspectionEvent } from './types';
 import WebSocket from 'isomorphic-ws';
 import safeStringify from 'safe-stable-stringify';
-import { Observer, Subscribable, toObserver } from 'xstate';
+import type { Observer, Subscribable } from 'xstate';
+import { toObserver } from './utils';
 
 export interface WebSocketInspectorOptions extends InspectorOptions {
   url: string;


### PR DESCRIPTION
This PR makes it possible to use `@statelyai/inspect` without needing to also install `xstate`.