### PR TITLE
Better serialization

### DIFF
--- a/.changeset/twelve-tomatoes-cover.md
+++ b/.changeset/twelve-tomatoes-cover.md
@@ -1,0 +1,5 @@
+---
+'@statelyai/inspect': minor
+---
+
+The `serialize` option will now pre-serialize the event using `superjson` before the custom serialization.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,10 @@
 import safeStringify from 'fast-safe-stringify';
 import { AnyEventObject, Observer, Subscribable, toObserver } from 'xstate';
-import { InspectorOptions, createInspector } from './createInspector';
+import {
+  InspectorOptions,
+  createInspector,
+  defaultInspectorOptions,
+} from './createInspector';
 import { Adapter, Inspector, StatelyInspectionEvent } from './types';
 import { UselessAdapter } from './useless';
 
@@ -165,7 +169,14 @@ export class BrowserAdapter implements Adapter {
       ) {
         this.status = 'connected';
         this.deferredEvents.forEach((event) => {
-          const serializedEvent = this.options.serialize(event);
+          const preSerializedEvent = defaultInspectorOptions.serialize(
+            event,
+            event
+          );
+          const serializedEvent = this.options.serialize(
+            preSerializedEvent,
+            event
+          );
           this.targetWindow?.postMessage(serializedEvent, '*');
         });
       }
@@ -184,7 +195,11 @@ export class BrowserAdapter implements Adapter {
     if (this.options.send) {
       this.options.send(event);
     } else if (this.status === 'connected') {
-      const serializedEvent = this.options.serialize(event);
+      const preSerializedEvent = defaultInspectorOptions.serialize(
+        event,
+        event
+      );
+      const serializedEvent = this.options.serialize(preSerializedEvent, event);
       this.targetWindow?.postMessage(serializedEvent, '*');
     }
 

--- a/src/createInspector.test.ts
+++ b/src/createInspector.test.ts
@@ -61,7 +61,7 @@ test('Creates an inspector for a state machine', async () => {
           },
           {
             "event": {
-              "input": undefined,
+              "input": null,
               "type": "xstate.init",
             },
             "sessionId": "x:0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export type {
   StatelySnapshotEvent,
 } from './types';
 export { createWebSocketInspector, createWebSocketReceiver } from './webSocket';
+export { createReduxDevToolsInspector } from './redux';


### PR DESCRIPTION
The `serialize` option will now pre-serialize the event using `superjson` before the custom serialization.
