### PR TITLE
Add sanitization

### DIFF
--- a/.changeset/neat-beans-wave.md
+++ b/.changeset/neat-beans-wave.md
@@ -1,0 +1,24 @@
+---
+"@statelyai/inspect": minor
+---
+
+Added new options `sanitizeContext` and `sanitizeEvent` to the inspector configuration. These options allow users to sanitize sensitive data from the context and events before they are sent to the inspector, and also to remove non-serializable data. 
+
+Example usage:
+
+```typescript
+const inspector = createInspector({
+  sanitizeContext: (context) => {
+    // Remove sensitive data from context
+    const { password, ...safeContext } = context;
+    return safeContext;
+  },
+  sanitizeEvent: (event) => {
+    // Remove sensitive data from event
+    if (event.type === 'SUBMIT_FORM') {
+      const { creditCardNumber, ...safeEvent } = event;
+      return safeEvent;
+    }
+    return event;
+  }
+});

--- a/src/createInspector.test.ts
+++ b/src/createInspector.test.ts
@@ -260,6 +260,69 @@ test('options.serialize', async () => {
   });
 });
 
+test('Sanitization options', async () => {
+  const events: StatelyInspectionEvent[] = [];
+  const testAdapter: Adapter = {
+    send: (event) => {
+      events.push(event);
+    },
+    start: () => {},
+    stop: () => {},
+  };
+  const inspector = createInspector(testAdapter, {
+    sanitizeContext: (ctx) => ({
+      ...ctx,
+      user: 'anonymous',
+    }),
+    sanitizeEvent: (ev) => {
+      if ('user' in ev) {
+        return { ...ev, user: 'anonymous' };
+      } else {
+        return ev;
+      }
+    },
+  });
+
+  inspector.actor('test', { context: { user: 'David' } });
+
+  expect((events[0] as StatelyActorEvent).snapshot.context).toEqual({
+    user: 'anonymous',
+  });
+
+  inspector.snapshot('test', { context: { user: 'David' } });
+
+  expect((events[1] as StatelyActorEvent).snapshot.context).toEqual({
+    user: 'anonymous',
+  });
+
+  inspector.event('test', { type: 'updateUser', user: 'David' });
+
+  expect((events[2] as StatelyEventEvent).event).toEqual({
+    type: 'updateUser',
+    user: 'anonymous',
+  });
+
+  inspector.inspect.next?.({
+    type: '@xstate.event',
+    actorRef: {} as any,
+    event: {
+      type: 'setUser',
+      user: 'Another',
+    },
+    rootId: '',
+    sourceRef: undefined,
+  });
+
+  await new Promise<void>((res) => {
+    setTimeout(res, 10);
+  });
+
+  expect((events[3] as StatelyEventEvent).event).toEqual({
+    type: 'setUser',
+    user: 'anonymous',
+  });
+});
+
 test('it safely stringifies objects with circular dependencies', () => {
   const events: StatelyInspectionEvent[] = [];
   const testAdapter: Adapter = {


### PR DESCRIPTION
Added new options `sanitizeContext` and `sanitizeEvent` to the inspector configuration. These options allow users to sanitize sensitive data from the context and events before they are sent to the inspector, and also to remove non-serializable data. 

Example usage:

```ts
const inspector = createInspector({
  sanitizeContext: (context) => {
    // Remove sensitive data from context
    const { password, ...safeContext } = context;
    return safeContext;
  },
  sanitizeEvent: (event) => {
    // Remove sensitive data from event
    if (event.type === 'SUBMIT_FORM') {
      const { creditCardNumber, ...safeEvent } = event;
      return safeEvent;
    }
    return event;
  }
});
```