### PR TITLE
Fix remove-node-module-import

### DIFF
--- a/src/createSkyInspector.ts
+++ b/src/createSkyInspector.ts
@@ -1,3 +1,4 @@
+import IsomorphicWebSocket from 'isomorphic-ws';
 import PartySocket from 'partysocket';
 import { stringify } from 'superjson';
 import { v4 as uuidv4 } from 'uuid';
@@ -32,7 +33,7 @@ export function createSkyInspector(
   const socket = new PartySocket({
     host,
     room,
-    WebSocket: isNode ? require('isomorphic-ws') : undefined,
+    WebSocket: isNode ? IsomorphicWebSocket : undefined,
   });
   const liveInspectUrl = `${server}/inspect/${sessionId}`;
   socket.onerror = onerror ?? console.error;


### PR DESCRIPTION
The require() call in createSkyInspector.ts causes rolldown to emit `import { createRequire } from "node:module"` in dist/index.mjs, breaking browser usage of the package.

Since isomorphic-ws provides a browser-safe entry via its "browser" field in package.json, this fix uses a static ESM import instead of require().

Tested in Vite, _seems_ to fix the issue :) 